### PR TITLE
Make use of l_db_user or l_db_pass completely optional and add new config option r_db_host

### DIFF
--- a/config-sample
+++ b/config-sample
@@ -11,7 +11,8 @@ l_db_pass= # local database password
 
 r_db_name= # remote database name
 r_db_user= # remote database user
-r_db_pass= # remoate database password
+r_db_pass= # remote database password
+r_db_host= # use if the remote database is running on a different host, but only reachable from the r_host
 
 l_upload_dir= # optional – local wordpress upload folder www/wp-content/uploads/ (relative to local working directory)
 r_upload_dir= # optional – remote wordpress upload folder project/www/wp-content/uploads/ (relative to remote login/home directory)

--- a/wpsync
+++ b/wpsync
@@ -84,15 +84,15 @@ push_db () {
 
   ssh $r_user@$r_host "mkdir $r_dir/$wpsyncdir"
 
-    echo "uploading local db"
+  echo "uploading local db"
 
-    scp $wpsyncdir/local-db.sql $r_user@$r_host:$r_dir/$wpsyncdir/
+  scp $wpsyncdir/local-db.sql $r_user@$r_host:$r_dir/$wpsyncdir/
 
   rm $wpsyncdir/local-db.sql
 
-    echo "${green}ready.${reset}"
+  echo "${green}ready.${reset}"
 
-    echo "dumping remote db as backup && populate remote db with local db"
+  echo "dumping remote db as backup && populate remote db with local db"
 
   if [ -n "${r_db_host+x}" ] ; then
 

--- a/wpsync
+++ b/wpsync
@@ -48,19 +48,19 @@ help (){
 
 push_db () {
 
-	echo "dump local db"
+  echo "dump local db"
 
-	mysqldump -u $l_db_user -p$l_db_pass $l_db_name > $wpsyncdir/local-db.sql
+  mysqldump -u $l_db_user -p$l_db_pass $l_db_name > $wpsyncdir/local-db.sql
 
   #search and replace
   cp $wpsyncdir/local-db.sql $wpsyncdir/local-db.$current_date.sql.bak
-  sed -i "" "s,$l_web_addr,$r_web_addr,g" $wpsyncdir/local-db.sql
+  sed -i "s,$l_web_addr,$r_web_addr,g" $wpsyncdir/local-db.sql
 
   if [ -n "${r_db_charset+x}" ] && [ -n "${l_db_charset+x}" ] ; then
 
     echo "search replace database charset"
 
-    sed -i "" "s,$l_db_charset,$r_db_charset,g" $wpsyncdir/local-db.sql
+    sed -i "s,$l_db_charset,$r_db_charset,g" $wpsyncdir/local-db.sql
 
   fi
 
@@ -68,20 +68,20 @@ push_db () {
 
   ssh $r_user@$r_host "mkdir $r_dir/$wpsyncdir"
 
-	echo "uploading local db"
+  echo "uploading local db"
 
-	scp $wpsyncdir/local-db.sql $r_user@$r_host:$r_dir/$wpsyncdir/
+  scp $wpsyncdir/local-db.sql $r_user@$r_host:$r_dir/$wpsyncdir/
 
   rm $wpsyncdir/local-db.sql
 
-	echo "${green}ready.${reset}"
+  echo "${green}ready.${reset}"
 
-	echo "dumping remote db as backup && populate remote db with local db"
+  echo "dumping remote db as backup && populate remote db with local db"
 
-	ssh $r_user@$r_host "mysqldump -u $r_db_user -p$r_db_pass $r_db_name > $r_dir/$wpsyncdir/remote-db.sql \
-	&& mysql -u $r_db_user -p$r_db_pass $r_db_name < $r_dir/$wpsyncdir/local-db.sql"
+  ssh $r_user@$r_host "mysqldump -u $r_db_user -p$r_db_pass $r_db_name > $r_dir/$wpsyncdir/remote-db.sql \
+  && mysql -u $r_db_user -p$r_db_pass $r_db_name < $r_dir/$wpsyncdir/local-db.sql"
 
-	echo "ready."
+  echo "ready."
 
 }
 
@@ -106,13 +106,13 @@ pull_db(){
 
   echo "search replace web address strings"
 
-  sed -i "" "s,$r_web_addr,$l_web_addr,g" $wpsyncdir/remote-db.sql
+  sed -i "s,$r_web_addr,$l_web_addr,g" $wpsyncdir/remote-db.sql
 
   if [ -n "${r_db_charset+x}" ] && [ -n "${l_db_charset+x}" ] ; then
 
     echo "search replace database charset"
 
-    sed -i "" "s,$r_db_charset,$l_db_charset,g" $wpsyncdir/remote-db.sql
+    sed -i "s,$r_db_charset,$l_db_charset,g" $wpsyncdir/remote-db.sql
 
   fi
 
@@ -122,7 +122,7 @@ pull_db(){
 
   echo "cleanup"
   #remove remote sql dump locally
-  rm $wpsyncdir/remote-db.sql
+  #rm $wpsyncdir/remote-db.sql
 
   echo "${green}ready.${reset}"
 

--- a/wpsync
+++ b/wpsync
@@ -48,7 +48,7 @@ help (){
 
 push_db () {
 
-	echo "dump local db"
+  echo "dump local db"
 
   if [ -n "${l_db_user+x}" ] && [ -n "${l_db_pass+x}" ] ; then
 
@@ -84,15 +84,15 @@ push_db () {
 
   ssh $r_user@$r_host "mkdir $r_dir/$wpsyncdir"
 
-	echo "uploading local db"
+    echo "uploading local db"
 
-	scp $wpsyncdir/local-db.sql $r_user@$r_host:$r_dir/$wpsyncdir/
+    scp $wpsyncdir/local-db.sql $r_user@$r_host:$r_dir/$wpsyncdir/
 
   rm $wpsyncdir/local-db.sql
 
-	echo "${green}ready.${reset}"
+    echo "${green}ready.${reset}"
 
-	echo "dumping remote db as backup && populate remote db with local db"
+    echo "dumping remote db as backup && populate remote db with local db"
 
   if [ -n "${r_db_host+x}" ] ; then
 
@@ -294,7 +294,7 @@ if [ -z "${r_plugin_dir:-}" ] ; then
 fi
 
 
-for var in r_user r_host r_dir r_web_addr l_web_addr l_db_name l_db_pass l_db_user r_db_name r_db_user r_db_pass l_upload_dir r_upload_dir l_db_charset r_db_charset l_plugin_dir r_plugin_dir; do
+for var in r_user r_host r_dir r_web_addr l_web_addr l_db_name l_db_pass l_db_user r_db_name r_db_user r_db_pass r_db_host l_upload_dir r_upload_dir l_db_charset r_db_charset l_plugin_dir r_plugin_dir; do
     if [ -n "$var+x" ] ; then
         echo "$var is set to ${var}"
     else

--- a/wpsync
+++ b/wpsync
@@ -48,19 +48,19 @@ help (){
 
 push_db () {
 
-  echo "dump local db"
+	echo "dump local db"
 
-  mysqldump -u $l_db_user -p$l_db_pass $l_db_name > $wpsyncdir/local-db.sql
+	mysqldump -u $l_db_user -p$l_db_pass $l_db_name > $wpsyncdir/local-db.sql
 
   #search and replace
   cp $wpsyncdir/local-db.sql $wpsyncdir/local-db.$current_date.sql.bak
-  sed -i "s,$l_web_addr,$r_web_addr,g" $wpsyncdir/local-db.sql
+  sed -i "" "s,$l_web_addr,$r_web_addr,g" $wpsyncdir/local-db.sql
 
   if [ -n "${r_db_charset+x}" ] && [ -n "${l_db_charset+x}" ] ; then
 
     echo "search replace database charset"
 
-    sed -i "s,$l_db_charset,$r_db_charset,g" $wpsyncdir/local-db.sql
+    sed -i "" "s,$l_db_charset,$r_db_charset,g" $wpsyncdir/local-db.sql
 
   fi
 
@@ -68,20 +68,20 @@ push_db () {
 
   ssh $r_user@$r_host "mkdir $r_dir/$wpsyncdir"
 
-  echo "uploading local db"
+	echo "uploading local db"
 
-  scp $wpsyncdir/local-db.sql $r_user@$r_host:$r_dir/$wpsyncdir/
+	scp $wpsyncdir/local-db.sql $r_user@$r_host:$r_dir/$wpsyncdir/
 
   rm $wpsyncdir/local-db.sql
 
-  echo "${green}ready.${reset}"
+	echo "${green}ready.${reset}"
 
-  echo "dumping remote db as backup && populate remote db with local db"
+	echo "dumping remote db as backup && populate remote db with local db"
 
-  ssh $r_user@$r_host "mysqldump -u $r_db_user -p$r_db_pass $r_db_name > $r_dir/$wpsyncdir/remote-db.sql \
-  && mysql -u $r_db_user -p$r_db_pass $r_db_name < $r_dir/$wpsyncdir/local-db.sql"
+	ssh $r_user@$r_host "mysqldump -u $r_db_user -p$r_db_pass $r_db_name > $r_dir/$wpsyncdir/remote-db.sql \
+	&& mysql -u $r_db_user -p$r_db_pass $r_db_name < $r_dir/$wpsyncdir/local-db.sql"
 
-  echo "ready."
+	echo "ready."
 
 }
 
@@ -106,13 +106,13 @@ pull_db(){
 
   echo "search replace web address strings"
 
-  sed -i "s,$r_web_addr,$l_web_addr,g" $wpsyncdir/remote-db.sql
+  sed -i "" "s,$r_web_addr,$l_web_addr,g" $wpsyncdir/remote-db.sql
 
   if [ -n "${r_db_charset+x}" ] && [ -n "${l_db_charset+x}" ] ; then
 
     echo "search replace database charset"
 
-    sed -i "s,$r_db_charset,$l_db_charset,g" $wpsyncdir/remote-db.sql
+    sed -i "" "s,$r_db_charset,$l_db_charset,g" $wpsyncdir/remote-db.sql
 
   fi
 
@@ -122,7 +122,7 @@ pull_db(){
 
   echo "cleanup"
   #remove remote sql dump locally
-  #rm $wpsyncdir/remote-db.sql
+  rm $wpsyncdir/remote-db.sql
 
   echo "${green}ready.${reset}"
 

--- a/wpsync
+++ b/wpsync
@@ -50,7 +50,23 @@ push_db () {
 
 	echo "dump local db"
 
-	mysqldump -u $l_db_user -p$l_db_pass $l_db_name > $wpsyncdir/local-db.sql
+  if [ -n "${l_db_user+x}" ] && [ -n "${l_db_pass+x}" ] ; then
+
+    mysqldump -u $l_db_user -p$l_db_pass $l_db_name > $wpsyncdir/local-db.sql
+
+  elif [ -n "${l_db_user+x}" ] ; then
+
+    mysqldump -u $l_db_user $l_db_name > $wpsyncdir/local-db.sql
+
+  elif [ -n "${l_db_pass+x}" ] ; then
+
+    mysqldump -p$l_db_pass $l_db_name > $wpsyncdir/local-db.sql
+
+  else
+
+    mysqldump $l_db_name > $wpsyncdir/local-db.sql 
+
+  fi
 
   #search and replace
   cp $wpsyncdir/local-db.sql $wpsyncdir/local-db.$current_date.sql.bak
@@ -78,10 +94,19 @@ push_db () {
 
 	echo "dumping remote db as backup && populate remote db with local db"
 
-	ssh $r_user@$r_host "mysqldump -u $r_db_user -p$r_db_pass $r_db_name > $r_dir/$wpsyncdir/remote-db.sql \
-	&& mysql -u $r_db_user -p$r_db_pass $r_db_name < $r_dir/$wpsyncdir/local-db.sql"
+  if [ -n "${r_db_host+x}" ] ; then
 
-	echo "ready."
+    ssh $r_user@$r_host "mysqldump -h $r_db_host -u $r_db_user -p$r_db_pass $r_db_name > $r_dir/$wpsyncdir/remote-db.sql \
+    && mysql -u $r_db_user -h $r_db_host -p$r_db_pass $r_db_name < $r_dir/$wpsyncdir/local-db.sql"
+
+  else
+
+    ssh $r_user@$r_host "mysqldump -u $r_db_user -p$r_db_pass $r_db_name > $r_dir/$wpsyncdir/remote-db.sql \
+    && mysql -u $r_db_user -p$r_db_pass $r_db_name < $r_dir/$wpsyncdir/local-db.sql"
+
+  fi
+
+  echo "ready."
 
 }
 
@@ -89,11 +114,35 @@ pull_db(){
 
   echo "dump local db as backup"
 
-  mysqldump -u $l_db_user -p$l_db_pass $l_db_name > $wpsyncdir/local-db.${current_date}.sql.bak
+  if [ -n "${l_db_user+x}" ] && [ -n "${l_db_pass+x}" ] ; then
+
+    mysqldump -u $l_db_user -p$l_db_pass $l_db_name > $wpsyncdir/local-db.${current_date}.sql.bak
+
+  elif [ -n "${l_db_user+x}" ] ; then
+
+    mysqldump -u $l_db_user $l_db_name > $wpsyncdir/local-db.${current_date}.sql.bak
+
+  elif [ -n "${l_db_pass+x}" ] ; then
+
+    mysqldump -p$l_db_pass $l_db_name > $wpsyncdir/local-db.${current_date}.sql.bak
+
+  else
+
+    mysqldump $l_db_name > $wpsyncdir/local-db.${current_date}.sql.bak
+
+  fi
 
   echo "dump remote db"
 
-  ssh $r_user@$r_host "mysqldump -u $r_db_user -p$r_db_pass $r_db_name > $r_dir/$wpsyncdir/remote-db.sql"
+  if [ -n "${r_db_host+x}" ] ; then
+
+    ssh $r_user@$r_host "mysqldump -h $r_db_host -u $r_db_user -p$r_db_pass $r_db_name > $r_dir/$wpsyncdir/remote-db.sql"
+
+  else
+
+    ssh $r_user@$r_host "mysqldump -u $r_db_user -p$r_db_pass $r_db_name > $r_dir/$wpsyncdir/remote-db.sql"
+
+  fi
 
   echo "downloading remote db"
 
@@ -118,7 +167,23 @@ pull_db(){
 
   echo "populate local db with remote db"
 
-  mysql -u $l_db_user -p$l_db_pass $l_db_name < $wpsyncdir/remote-db.sql
+  if [ -n "${l_db_user+x}" ] && [ -n "${l_db_pass+x}" ] ; then
+
+    mysql -u $l_db_user -p$l_db_pass $l_db_name < $wpsyncdir/remote-db.sql
+
+  elif [ -n "${l_db_user+x}" ] ; then
+
+    mysql -u $l_db_user $l_db_name < $wpsyncdir/remote-db.sql
+
+  elif [ -n "${l_db_pass+x}" ] ; then
+
+    mysql -p$l_db_pass $l_db_name < $wpsyncdir/remote-db.sql
+
+  else
+
+    mysql $l_db_name < $wpsyncdir/remote-db.sql
+
+  fi
 
   echo "cleanup"
   #remove remote sql dump locally


### PR DESCRIPTION
Sometimes you don’t want to use username and/or password on the command line explicitly, because you have it in your .my.cnf anyway or it’s even forbidden. Therefore I added some if/else clauses to use local username and/or pass on the command line only if the variables are set in the config. This would of course be a nice-to-have for the remote side, too, but I didn’t need it until now so I didn’t implement it :)

Then I added a new config variable: r_db_host. Sometimes you have wordpress installed on a remote host, but the database lives on even another host, with access restricted to the remote host. That’s what this option is for. Basically it just checks whether r_db_host is set and if so, the additional mysqldump command line option -h $r_db_host is supplied.

Also, I cleaned up some indentation.
